### PR TITLE
fix: default watch option is false in the show command

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -49,7 +49,7 @@ struct Show {
     #[clap(value_parser)]
     /// Enter the profile name you want to check.
     profile: String,
-    #[clap(short, long, action = ArgAction::SetFalse)]
+    #[clap(short, long, action = ArgAction::SetTrue)]
     /// After showing code, watch for changes.
     watch: bool,
 }


### PR DESCRIPTION
`SetFalse` action's default is True
https://docs.rs/clap/latest/clap/enum.ArgAction.html#variant.SetFalse
